### PR TITLE
APedia - Fixed hardcoded user post bug

### DIFF
--- a/apedia/topic.php
+++ b/apedia/topic.php
@@ -55,7 +55,7 @@ session_start();
 
             if (isset($_POST["text"])) {
                 $text = $_POST["text"];
-                $handler->insertQuestion($text, $topic_id, 1);
+                $handler->insertQuestion($text, $topic_id, $_SESSION["id"]);
                 header("Refresh:0");
             }
 


### PR DESCRIPTION
In Line 58 of topic.php, the user post id was hard coded as 1 instead of the id of the logged in user. So despite the account the client was logged into, all posts were created under the first user's id.