### PR TITLE
APedia- Fixed bug where home page was missing when logged in

### DIFF
--- a/apedia/index.php
+++ b/apedia/index.php
@@ -27,7 +27,7 @@ session_start();
 
 <ul class="nav">
     <?php
-    if (isset($_SESSION["loggedin"]) && $_SESSION(["loggedin"]) === true) {
+    if (isset($_SESSION["loggedin"]) && $_SESSION["loggedin"] === true) {
         $username = $_SESSION["username"];
         $id = $_SESSION["id"];
         echo "<li>Logged in as <a href='user.php?id=$id'>$username</a>. <a href='logout.php'>Log out</a></li>";


### PR DESCRIPTION
Unfortunately, I think I caused this bug when I submitted PR #4 . 

On line 30, SESSION was being called like a function: `$_SESSION(["loggedin"])`

This PR just removes the parentheses, and APedia works correctly after that.

This PR resolves #5 