### PR TITLE
OpenChat - Fixed NaN Seconds Ago Bug

### DIFF
--- a/openchat/script.js
+++ b/openchat/script.js
@@ -84,7 +84,7 @@ function addMessages(messages, top=false) {
 
         const div = document.createElement('div');
         div.id = msg.id;
-        div.setAttribute("data-post-date", msg["post_date"] + " UTC");
+        div.setAttribute("data-post-date", msg["post_date"].replace(' ', 'T') + "Z");
         div.classList.add('message');
 
         const time = document.createElement('p');


### PR DESCRIPTION
Currently, OpenChat displays all message post times as "NaN Seconds Ago". This is not good.

The format in the `data-post-date` attribute is not a valid datetime format for the `Date.parse()` function used to parse it. 

This fix changes the `data-post-date` attribute to a valid ISO 8601 format that JavaScript can parse. This requires no database migration or anything.

The new format used is `YYYY-MM-DDTHH:MM:SSZ`. An example looks like `2019-05-27T20:27:26Z`